### PR TITLE
Remove setuptools from install_require in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ name = 'check_po'
 version = read_relative_file('VERSION').strip()
 readme = read_relative_file('README')
 requirements = [
-    'setuptools',
     'polib',
 ]
 


### PR DESCRIPTION
It is unsafe and not recommended to include setuptools in the
install_require. Removing it to avoid conflict with other packages and
the python packaging pip and others.