### PR TITLE
Change for Apache 2 License

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,5 @@
 Benoît Bryon <benoit@marmelune.net>
-Natim <hubscher.remy@gmail.com>
 Nicolas Dubois <wo0dyn@ultimatesoftware.com>
 Raphaël Barrois <raphael.barrois@polyconseil.fr>
-Rémy HUBSCHER <hubscher.remy@gmail.com>
-Rémy HUBSCHER <remy@chefclub.tv>
-aRkadeFR <contact@arkade.info>
+Rémy “Natim” HUBSCHER <hubscher.remy@gmail.com>
+Florian Grignon <contact@arkade.info>

--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,13 @@
-check_po, python package to automate task on traduction file .po
-Copyright (C) PeopleDoc
+Copyright 2012 PeopleDoc Inc.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ author_email = hubscher.remy@gmail.com
 summary = Check_po to verify if everything is translated and that no fuzzy are still here.
 description-file = README.rst
 home-page = https://github.com/peopledoc/check_po
-license = GPLv3+
+license = Apache License 2.0
 classifier =
     Programming Language :: Python
     Programming Language :: Python :: 3
@@ -24,7 +24,7 @@ classifier =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
-    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+    License :: OSI Approved :: Apache Software License
 keywords =
     translation
     po


### PR DESCRIPTION
## Rationale

PeopleDoc uses Apache 2 License[1] for OSS projects.

### References

1. https://www.apache.org/licenses/LICENSE-2.0

## Agreement required from external contributors

* [x] @mgu _on behalf of_ **PeopleDoc**/UKG HRSD
* [ ] @rbarrois • Raphaël Barrois <raphael.barrois@polyconseil.fr>
* [x] @Natim • Rémy “Natim” HUBSCHER <hubscher.remy@gmail.com>
